### PR TITLE
removed redundant userProfile views/serializers

### DIFF
--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,14 +1,11 @@
-from django.conf.urls import url
+from django.urls import path
 from django.conf.urls import include
-from django.views.generic import TemplateView
-from .views.user import UsersViewSet, verify_token
+from .views.user import UsersViewSet
 from rest_framework import routers
 # from .views.login import LoginView
 # from .views.logout import LogoutView
-# from .views.profile import UserProfileView, UserProfileDetail, DoctorProfileView, DoctorProfileDetail
 # from .views.reset_password import ResetPasswordCodeget
 # from .views.update_password import UpdatePasswordView
-from . import views
 
 
 router = routers.SimpleRouter()
@@ -24,12 +21,8 @@ urlpatterns = [
     # url(r'^reset-password/$', ResetPasswordCodeget.as_view()),
     # url(r'^update-password/$', UpdatePasswordView.as_view()),
 
-    # UserProfiles
-    # url(r'^user-profiles/$', UserProfileView.as_view()),
-    # url(r'^user-profiles/(?P<profile_id>[\d]+)$', UserProfileDetail.as_view()),
-
-    url(r'^', include(router.urls)),
-    url(r'^verify-token/$', verify_token),
+    # User/s
+    path('', include(router.urls)),
 ]
 
 urlpatterns += router.urls

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,4 +1,3 @@
-from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path, include
 


### PR DESCRIPTION
## Description
Just a skeletion for users and userProfile models are provided by UserSerializer and UserViewsets, so, redundant views and serializers related to userProfiles are removed.

**Todo:**
- [ ] : Research on drf CBVs and Serializers
- [ ] : suitable implementaion for all model-based views and serializers


## Motivation
best backend

## Related Issue
Part of #5 #7 #30 
Fixes  #15

## How this has been tested
- [x] :robot:

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feaure (non-breaking change which add functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
